### PR TITLE
Add support for XENO analog sensors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 3.6.2
+## 3.7.0
 
 - Add support for analog X-ENO sensors
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 3.6.2
+
+- Add support for analog X-ENO sensors
+
 ## 3.6.1
 
 - Add an option to invert the value read from a binary sensor

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ You can control by setting the type of the device:
 - `analogin` as sensor
 - `virtualanalogin` as sensor or number
 - `xdimmer` as light
+- `xeno` as sensor
 - `xpwm` as light
 - `xpwm_rgb` as light (use 3 xpwm channels)
 - `xpwm_rgbw` as light (use 4 xpwm channels)
@@ -116,6 +117,18 @@ ipx800v4:
         name: Compteur
         type: counter
         id: 1
+      - component: sensor
+        device_class: humidity
+        name: Humidité Salle de Bains
+        type: xeno
+        id: 123
+        unit_of_measurement: "%"
+      - component: sensor
+        device_class: temperature
+        name: Température Salle de Bains
+        type: xeno
+        id: 124
+        unit_of_measurement: "C"
 ```
 
 ## List of configuration parameters

--- a/custom_components/ipx800v4/__init__.py
+++ b/custom_components/ipx800v4/__init__.py
@@ -66,6 +66,7 @@ from .const import (
     TYPE_X4VR,
     TYPE_X4VR_BSO,
     TYPE_XDIMMER,
+    TYPE_XENO,
     TYPE_XPWM,
     TYPE_XPWM_RGB,
     TYPE_XPWM_RGBW,

--- a/custom_components/ipx800v4/const.py
+++ b/custom_components/ipx800v4/const.py
@@ -35,6 +35,7 @@ TYPE_VIRTUALANALOGIN = "virtualanalogin"
 TYPE_DIGITALIN = "digitalin"
 TYPE_X4VR = "x4vr"
 TYPE_X4VR_BSO = "x4vr_bso"
+TYPE_XENO = "xeno"
 TYPE_XTHL = "xthl"
 TYPE_X4FP = "x4fp"
 TYPE_COUNTER = "counter"
@@ -62,6 +63,7 @@ CONF_TYPE_ALLOWED = [
     TYPE_DIGITALIN,
     TYPE_X4VR,
     TYPE_X4VR_BSO,
+    TYPE_XENO,
     TYPE_XTHL,
     TYPE_X4FP,
     TYPE_COUNTER,

--- a/custom_components/ipx800v4/sensor.py
+++ b/custom_components/ipx800v4/sensor.py
@@ -24,6 +24,7 @@ from .const import (
     TYPE_ANALOGIN,
     TYPE_COUNTER,
     TYPE_VIRTUALANALOGIN,
+    TYPE_XENO,
     TYPE_XTHL,
 )
 
@@ -84,6 +85,14 @@ async def async_setup_entry(
                     suffix_name="Luminance",
                 )
             )
+        elif device.get(CONF_TYPE) == TYPE_XENO:
+            entities.append(
+                XENOSensor(
+                    device,
+                    controller,
+                    coordinator,
+                )
+            )
 
     async_add_entities(entities, True)
 
@@ -139,3 +148,11 @@ class XTHLSensor(IpxEntity, SensorEntity):
     def native_value(self) -> float:
         """Return the current value."""
         return round(self.coordinator.data[f"THL{self._id}-{self._req_type}"], 1)
+
+class XENOSensor(IpxEntity, SensorEntity):
+    """Representation of an Enocean sensor."""
+
+    @property
+    def native_value(self) -> float:
+        """Return the current value."""
+        return round(self.coordinator.data[f"ENO ANALOG{self._id - 121 + 17}"], 1)

--- a/custom_components/ipx800v4/sensor.py
+++ b/custom_components/ipx800v4/sensor.py
@@ -155,4 +155,4 @@ class XENOSensor(IpxEntity, SensorEntity):
     @property
     def native_value(self) -> float:
         """Return the current value."""
-        return round(self.coordinator.data[f"ENO ANALOG{self._id - 121 + 17}"], 1)
+        return round(self.coordinator.data[f"ENO ANALOG{int(self._id) - 121 + 17}"], 1)


### PR DESCRIPTION
I only added support for sensors. The numbering is pretty weird in the API response. The first analog device has index 17. To make it easier to configure, the code does the math to convert the ID seen in the IPX UI and the ID in the API.

[API doc snippet (page 23)](https://forum.gce-electronics.com/uploads/default/original/2X/6/62029bed365735c19fc19e44b02dd34d19a00012.pdf) :

```
Réponse type à un « Get=Xxx » avec en-tête (ici Get=XENO):
{
"product": "IPX800_V4",
"status": "Success",
....
"ENO ANALOG17": 0.00,
"ENO ANALOG18": 0,
"ENO ANALOG19": 0,
...
"ENO ANALOG39": 0,
"ENO ANALOG40": 0
}
```

