### PR TITLE
Add icon for climate custom preset_mode

### DIFF
--- a/custom_components/ipx800v4/climate.py
+++ b/custom_components/ipx800v4/climate.py
@@ -64,6 +64,8 @@ async def async_setup_entry(
 class X4FPClimate(IpxEntity, ClimateEntity):
     """Representation of a IPX Climate through X4FP."""
 
+    _attr_translation_key = "ipx800v4_climate"
+
     def __init__(
         self,
         device_config: dict,

--- a/custom_components/ipx800v4/icons.json
+++ b/custom_components/ipx800v4/icons.json
@@ -1,0 +1,18 @@
+{
+  "entity": {
+    "climate": {
+      "ipx800v4_climate": {
+        "state_attributes": {
+          "preset_mode": {
+            "state": {
+              "none": "mdi:power",
+              "away": "mdi:snowflake",
+              "comfort -1": "mdi:circle-slice-5",
+              "comfort -2": "mdi:circle-slice-3"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/custom_components/ipx800v4/icons.json
+++ b/custom_components/ipx800v4/icons.json
@@ -7,8 +7,8 @@
             "state": {
               "none": "mdi:power",
               "away": "mdi:snowflake",
-              "comfort -1": "mdi:circle-slice-5",
-              "comfort -2": "mdi:circle-slice-3"
+              "comfort -1": "mdi:thermometer-chevron-down",
+              "comfort -2": "mdi:thermometer-minus"
             }
           }
         }


### PR DESCRIPTION
Bonjour,

Petite proposition pour ajouter des icons sur les **`preset_mode`** des `entity climate` que home assistant ne connait pas.
C'est une fonctionnalité qui a été ajoutée sur la version 2024.01 de ha.

Actuellement :
![Capture_avant](https://github.com/user-attachments/assets/e599e6ab-ab82-40a1-8c06-2c8e23ff0d81)
Avec cette PR :
![Capture_apres](https://github.com/user-attachments/assets/0dd61bb4-ca66-4da7-97ed-ebdd4a22c586)

Je reste ouvert sur le choix des icons, j'ai choisi ce qui me semble le mieux, mais je ne suis pas fermé.
Merci !

