### PR TITLE
fix: mark entities unavailable instead of crashing when extension data is missing

### DIFF
--- a/custom_components/ipx800v4/binary_sensor.py
+++ b/custom_components/ipx800v4/binary_sensor.py
@@ -48,6 +48,11 @@ class VirtualOutBinarySensor(IpxEntity, BinarySensorEntity):
     """Representation of a IPX Virtual Out."""
 
     @property
+    def available(self) -> bool:
+        """Return True if the virtual output is present in the last update."""
+        return self._data_available(f"VO{self._id}")
+
+    @property
     def is_on(self) -> bool:
         """Return the state."""
         return self.coordinator.data[f"VO{self._id}"] == (
@@ -57,6 +62,11 @@ class VirtualOutBinarySensor(IpxEntity, BinarySensorEntity):
 
 class DigitalInBinarySensor(IpxEntity, BinarySensorEntity):
     """Representation of a IPX Virtual In."""
+
+    @property
+    def available(self) -> bool:
+        """Return True if the digital input is present in the last update."""
+        return self._data_available(f"D{self._id}")
 
     @property
     def is_on(self) -> bool:

--- a/custom_components/ipx800v4/climate.py
+++ b/custom_components/ipx800v4/climate.py
@@ -90,6 +90,11 @@ class X4FPClimate(IpxEntity, ClimateEntity):
         ]
 
     @property
+    def available(self) -> bool:
+        """Return True if the zone data is present in the last update."""
+        return self._data_available(f"FP{self._ext_id} Zone {self._id}")
+
+    @property
     def hvac_mode(self) -> HVACMode | None:
         """Return current mode if heating or not."""
         if (
@@ -184,6 +189,11 @@ class RelayClimate(IpxEntity, ClimateEntity):
         self._attr_temperature_unit = UnitOfTemperature.CELSIUS
         self._attr_hvac_modes = [HVACMode.HEAT, HVACMode.OFF]
         self._attr_preset_modes = [PRESET_COMFORT, PRESET_ECO, PRESET_AWAY, PRESET_NONE]
+
+    @property
+    def available(self) -> bool:
+        """Return True if both relay states are present in the last update."""
+        return self._data_available(f"R{self._ids[0]}", f"R{self._ids[1]}")
 
     @property
     def hvac_mode(self) -> HVACMode | None:

--- a/custom_components/ipx800v4/cover.py
+++ b/custom_components/ipx800v4/cover.py
@@ -76,23 +76,17 @@ class X4VRCover(IpxEntity, CoverEntity):
     @property
     def available(self) -> bool:
         """Return True if the cover level is present in the last update."""
-        return super().available and self.control.key in self.coordinator.data
+        return self._data_available(f"VR{self._ext_id}-{self._id}")
 
     @property
-    def is_closed(self) -> bool | None:
+    def is_closed(self) -> bool:
         """Return the state."""
-        level = self.coordinator.data.get(self.control.key)
-        if level is None:
-            return None
-        return int(level) == 100
+        return int(self.coordinator.data[f"VR{self._ext_id}-{self._id}"]) == 100
 
     @property
-    def current_cover_position(self) -> int | None:
+    def current_cover_position(self) -> int:
         """Return the current cover position."""
-        level = self.coordinator.data.get(self.control.key)
-        if level is None:
-            return None
-        return 100 - int(level)
+        return 100 - int(self.coordinator.data[f"VR{self._ext_id}-{self._id}"])
 
     async def async_open_cover(self, **kwargs: Any) -> None:
         """Open cover."""

--- a/custom_components/ipx800v4/cover.py
+++ b/custom_components/ipx800v4/cover.py
@@ -74,14 +74,25 @@ class X4VRCover(IpxEntity, CoverEntity):
             )
 
     @property
-    def is_closed(self) -> bool:
-        """Return the state."""
-        return int(self.coordinator.data[f"VR{self._ext_id}-{self._id}"]) == 100
+    def available(self) -> bool:
+        """Return True if the cover level is present in the last update."""
+        return super().available and self.control.key in self.coordinator.data
 
     @property
-    def current_cover_position(self) -> int:
+    def is_closed(self) -> bool | None:
+        """Return the state."""
+        level = self.coordinator.data.get(self.control.key)
+        if level is None:
+            return None
+        return int(level) == 100
+
+    @property
+    def current_cover_position(self) -> int | None:
         """Return the current cover position."""
-        return 100 - int(self.coordinator.data[f"VR{self._ext_id}-{self._id}"])
+        level = self.coordinator.data.get(self.control.key)
+        if level is None:
+            return None
+        return 100 - int(level)
 
     async def async_open_cover(self, **kwargs: Any) -> None:
         """Open cover."""

--- a/custom_components/ipx800v4/entity.py
+++ b/custom_components/ipx800v4/entity.py
@@ -116,3 +116,15 @@ class IpxEntity(CoordinatorEntity):
             "via_device": (DOMAIN, self.ipx.host),
             "configuration_url": configuration_url,
         }
+
+    def _data_available(self, *keys: str) -> bool:
+        """Return True if the last update succeeded and contains all keys.
+
+        Extension data (X4VR, X4FP, X-THL, X-PWM, X-Dimmer...) can be
+        transiently absent from the IPX800 global response. In that case the
+        entity is marked unavailable for the cycle instead of raising a
+        KeyError when its state is computed.
+        """
+        return self.coordinator.last_update_success and all(
+            key in self.coordinator.data for key in keys
+        )

--- a/custom_components/ipx800v4/light.py
+++ b/custom_components/ipx800v4/light.py
@@ -95,6 +95,11 @@ class RelayLight(IpxEntity, LightEntity):
         self._attr_color_mode = ColorMode.ONOFF
 
     @property
+    def available(self) -> bool:
+        """Return True if the relay state is present in the last update."""
+        return self._data_available(f"R{self._id}")
+
+    @property
     def is_on(self) -> bool:
         """Return if the light is on."""
         return self.coordinator.data[f"R{self._id}"] == 1
@@ -147,6 +152,11 @@ class XDimmerLight(IpxEntity, LightEntity):
         self._attr_supported_color_modes = {ColorMode.BRIGHTNESS}
         self._attr_color_mode = ColorMode.BRIGHTNESS
         self._attr_supported_features = LightEntityFeature.TRANSITION
+
+    @property
+    def available(self) -> bool:
+        """Return True if the dimmer data is present in the last update."""
+        return self._data_available(f"G{self._id}")
 
     @property
     def is_on(self) -> bool:
@@ -218,6 +228,11 @@ class XPWMLight(IpxEntity, LightEntity):
         self._attr_supported_color_modes = {ColorMode.BRIGHTNESS}
         self._attr_color_mode = ColorMode.BRIGHTNESS
         self._attr_supported_features = LightEntityFeature.TRANSITION
+
+    @property
+    def available(self) -> bool:
+        """Return True if the PWM channel is present in the last update."""
+        return self._data_available(f"PWM{self._id}")
 
     @property
     def is_on(self) -> bool:
@@ -293,6 +308,13 @@ class XPWMRGBLight(IpxEntity, LightEntity):
         self._attr_supported_color_modes = {ColorMode.RGB}
         self._attr_color_mode = ColorMode.RGB
         self._attr_supported_features = LightEntityFeature.TRANSITION
+
+    @property
+    def available(self) -> bool:
+        """Return True if all PWM channels are present in the last update."""
+        return self._data_available(
+            f"PWM{self._ids[0]}", f"PWM{self._ids[1]}", f"PWM{self._ids[2]}"
+        )
 
     @property
     def is_on(self) -> bool:
@@ -429,6 +451,16 @@ class XPWMRGBWLight(IpxEntity, LightEntity):
         self._attr_supported_color_modes = {ColorMode.RGBW}
         self._attr_color_mode = ColorMode.RGBW
         self._attr_supported_features = LightEntityFeature.TRANSITION
+
+    @property
+    def available(self) -> bool:
+        """Return True if all PWM channels are present in the last update."""
+        return self._data_available(
+            f"PWM{self._ids[0]}",
+            f"PWM{self._ids[1]}",
+            f"PWM{self._ids[2]}",
+            f"PWM{self._ids[3]}",
+        )
 
     @property
     def is_on(self) -> bool:

--- a/custom_components/ipx800v4/number.py
+++ b/custom_components/ipx800v4/number.py
@@ -63,6 +63,11 @@ class CounterNumber(IpxEntity, NumberEntity):
         self.control = Counter(ipx, self._id)
 
     @property
+    def available(self) -> bool:
+        """Return True if the counter is present in the last update."""
+        return self._data_available(f"C{self._id}")
+
+    @property
     def native_value(self) -> float:
         """Return the current value."""
         return self.coordinator.data[f"C{self._id}"]
@@ -84,6 +89,11 @@ class VirtualAnalogInNumber(IpxEntity, NumberEntity):
         """Initialize the RelayLight."""
         super().__init__(device_config, ipx, coordinator)
         self.control = VAInput(ipx, self._id)
+
+    @property
+    def available(self) -> bool:
+        """Return True if the virtual analog input is present in the last update."""
+        return self._data_available(f"VA{self._id}")
 
     @property
     def native_value(self) -> float:

--- a/custom_components/ipx800v4/sensor.py
+++ b/custom_components/ipx800v4/sensor.py
@@ -177,11 +177,11 @@ class XENOSensor(IpxEntity, SensorEntity):
     @property
     def available(self) -> bool:
         """Return True if the sensor value is present in the last update."""
-        analog_id = int(str(self._id)) - 121 + 17
-        return self._data_available(f"ENO ANALOG{analog_id!s}")
+        analog_id = int(self._id) - 121 + 17
+        return self._data_available(f"ENO ANALOG{analog_id}")
 
     @property
     def native_value(self) -> float:
         """Return the current value."""
-        analog_id = int(str(self._id)) - 121 + 17
-        return round(self.coordinator.data[f"ENO ANALOG{analog_id!s}"], 1)
+        analog_id = int(self._id) - 121 + 17
+        return round(self.coordinator.data[f"ENO ANALOG{analog_id}"], 1)

--- a/custom_components/ipx800v4/sensor.py
+++ b/custom_components/ipx800v4/sensor.py
@@ -102,6 +102,11 @@ class AnalogInSensor(IpxEntity, SensorEntity):
     """Representation of a IPX sensor through analog input."""
 
     @property
+    def available(self) -> bool:
+        """Return True if the analog input is present in the last update."""
+        return self._data_available(f"A{self._id}")
+
+    @property
     def native_value(self) -> float:
         """Return the current value."""
         return self.coordinator.data[f"A{self._id}"]
@@ -111,6 +116,11 @@ class CounterSensor(IpxEntity, SensorEntity):
     """Representation of a IPX sensor through analog input."""
 
     @property
+    def available(self) -> bool:
+        """Return True if the counter is present in the last update."""
+        return self._data_available(f"C{self._id}")
+
+    @property
     def native_value(self) -> float:
         """Return the current value."""
         return self.coordinator.data[f"C{self._id}"]
@@ -118,6 +128,11 @@ class CounterSensor(IpxEntity, SensorEntity):
 
 class VirtualAnalogInSensor(IpxEntity, SensorEntity):
     """Representation of a IPX sensor through virtual analog input."""
+
+    @property
+    def available(self) -> bool:
+        """Return True if the virtual analog input is present in the last update."""
+        return self._data_available(f"VA{self._id}")
 
     @property
     def native_value(self) -> float:
@@ -146,6 +161,11 @@ class XTHLSensor(IpxEntity, SensorEntity):
         self._req_type = req_type
 
     @property
+    def available(self) -> bool:
+        """Return True if the sensor value is present in the last update."""
+        return self._data_available(f"THL{self._id}-{self._req_type}")
+
+    @property
     def native_value(self) -> float:
         """Return the current value."""
         return round(self.coordinator.data[f"THL{self._id}-{self._req_type}"], 1)
@@ -153,6 +173,12 @@ class XTHLSensor(IpxEntity, SensorEntity):
 
 class XENOSensor(IpxEntity, SensorEntity):
     """Representation of an Enocean sensor."""
+
+    @property
+    def available(self) -> bool:
+        """Return True if the sensor value is present in the last update."""
+        analog_id = int(str(self._id)) - 121 + 17
+        return self._data_available(f"ENO ANALOG{analog_id!s}")
 
     @property
     def native_value(self) -> float:

--- a/custom_components/ipx800v4/switch.py
+++ b/custom_components/ipx800v4/switch.py
@@ -65,6 +65,11 @@ class RelaySwitch(IpxEntity, SwitchEntity):
         self.control = Relay(ipx, self._id)
 
     @property
+    def available(self) -> bool:
+        """Return True if the relay state is present in the last update."""
+        return self._data_available(f"R{self._id}")
+
+    @property
     def is_on(self) -> bool:
         """Return the state."""
         return self.coordinator.data[f"R{self._id}"] == 1
@@ -108,6 +113,11 @@ class VirtualOutSwitch(IpxEntity, SwitchEntity):
         """Initialize the VirtualOutSwitch."""
         super().__init__(device_config, ipx, coordinator)
         self.control = VOutput(ipx, self._id)
+
+    @property
+    def available(self) -> bool:
+        """Return True if the virtual output is present in the last update."""
+        return self._data_available(f"VO{self._id}")
 
     @property
     def is_on(self) -> bool:
@@ -155,6 +165,11 @@ class VirtualInSwitch(IpxEntity, SwitchEntity):
         """Initialize the VirtualInSwitch."""
         super().__init__(device_config, ipx, coordinator)
         self.control = VInput(ipx, self._id)
+
+    @property
+    def available(self) -> bool:
+        """Return True if the virtual input is present in the last update."""
+        return self._data_available(f"VI{self._id}")
 
     @property
     def is_on(self) -> bool:


### PR DESCRIPTION
## Problem

When data exposed by an extension (X-4VR, X-4FP, X-THL, X-PWM, X-Dimmer, XENO…) is transiently absent from the IPX800 `Get=all` response, entities read their value directly from `coordinator.data[...]` and raise a `KeyError`. The exception propagates through `async_write_ha_state` and breaks the state update for **every** affected listener.

Reported with an X-4VR cover — the 7 occurrences all fired at the same instant, i.e. a single update cycle where the extension data was missing:

```
Traceback (most recent call last):
  File ".../helpers/update_coordinator.py", line 201, in async_update_listeners
    update_callback()
  ...
  File ".../components/cover/__init__.py", line 249, in state
    if (closed := self.is_closed) is None:
  File ".../custom_components/ipx800v4/cover.py", line 79, in is_closed
    return int(self.coordinator.data[f"VR{self._ext_id}-{self._id}"]) == 100
KeyError: 'VR1-1'
```

## Root cause

The coordinator polls the device with `IPX800.global_get()` → `Get=all`. Base data (relays, virtual I/O, analog, counters…) is always present, but data coming from extensions can be momentarily missing from that aggregated response (bus read / timeout hiccup). The value properties (`is_closed`, `native_value`, `is_on`, `rgb_color`, `hvac_mode`…) index the key directly, so a missing key raises instead of degrading gracefully.

## Fix

Add a small helper on the shared `IpxEntity` base class and an `available` override on every entity that requires its key(s) to be present in the latest update:

```python
def _data_available(self, *keys: str) -> bool:
    return self.coordinator.last_update_success and all(
        key in self.coordinator.data for key in keys
    )
```

When a required key is missing, the entity is reported **unavailable** for that cycle (idiomatic Home Assistant behaviour) instead of raising. Since Home Assistant only reads an entity's state/attributes when it is available, the direct `coordinator.data[...]` reads stay unchanged and are now safe.

## Scope

`available` guard added to every entity class, on all platforms:

| Platform | Entities | Key(s) checked |
|---|---|---|
| cover | X4VR | `VR{ext}-{id}` |
| climate | X4FP, relay-based | `FP{ext} Zone {id}`, `R{ids}` |
| switch | relay, virtual out, virtual in | `R`, `VO`, `VI` |
| binary_sensor | virtual out, digital in | `VO`, `D` |
| sensor | analog, counter, virtual analog, X-THL, XENO | `A`, `C`, `VA`, `THL…`, `ENO ANALOG…` |
| light | relay, X-Dimmer, X-PWM, RGB, RGBW | `R`, `G`, `PWM` (1–4 channels) |
| number | counter, virtual analog | `C`, `VA` |

Also includes a tiny cleanup of the XENO key formatting (dropped a redundant `!s` conversion and `int(str(...))` wrapping — same produced key, no behaviour change).

## Behaviour change

None for correctly-configured entities: their keys are always present, so `available` stays `True`. When a key is momentarily missing, the entity now shows `unavailable` for that single cycle instead of logging a `KeyError` traceback and breaking the update.

## Validation

- `python -m py_compile` on all modules
- `ruff check` passes
- Each `available` guard checks exactly the key(s) read by its value property
- Logic test: key present → normal state; key missing → `unavailable`, no
  `KeyError`; failed update (`data is None`) → short-circuits, no `AttributeError`